### PR TITLE
feat: remove docker compose and change to example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ projects/
 
 .claude
 .claude.json
+
+docker-compose.yaml

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -10,7 +10,7 @@ services:
       - traefik-network
     labels:
       - traefik.enable=true
-      - traefik.http.routers.pr-automation.rule=Host(`bitbucket.tintinwinata.online`)
+      - traefik.http.routers.pr-automation.rule=Host(`YOUR_WEBSITE_URL`)
       - traefik.http.routers.pr-automation.tls=true
       - traefik.http.routers.pr-automation.entrypoints=web,websecure
       - traefik.http.routers.pr-automation.tls.certresolver=mytlschallenge


### PR DESCRIPTION
## Summary

This PR removes the docker-compose.yml file and changes it to docker-compose.yml.example, along with removing template-related functionality.

## Changes Made

- Removed docker-compose.yml and created docker-compose.yml.example
- Removed template management system (templateManager.js, template configs, and template files)
- Updated README.md to remove Jenkins-specific content
- Added contribution guide
- Updated .gitignore
- Enhanced claude.js with additional functionality

## Files Changed
- .gitignore (4 changes)
- README.md (71 changes) 
- TEMPLATE_GUIDE.md (removed - 272 lines)
- docker-compose.yml → docker-compose.yml.example
- src/claude.js (102 additions)
- src/config/template-config.json (removed)
- src/templateManager.js (removed - 190 lines)
- src/templates/ directory (removed all template files)

## Impact
- Simplifies the codebase by removing template management complexity
- Makes docker-compose configuration optional via example file
- Updates documentation and contribution guidelines