### PR TITLE
Add REST Client .http examples for BitBucket webhook testing

### DIFF
--- a/src/examples/bitbucket-pr-created.http
+++ b/src/examples/bitbucket-pr-created.http
@@ -1,0 +1,33 @@
+### Test Bitbucket Pull Request Created Webhook
+# Use with VS Code → REST Client extension (by Huachao Mao)
+# Make sure the server is running locally (npm start)
+# and BITBUCKET_WEBHOOK_SECRET is not set for easier local testing
+# ALLOWED_WORKSPACE must match the workspace below (xriopteam)
+
+POST http://localhost:3000/webhook/bitbucket/pr
+Content-Type: application/json
+x-event-key: pullrequest:created
+x-hub-signature: sha256=dummy-signature
+
+{
+  "repository": {
+    "name": "demo-by-rik",
+    "workspace": { "slug": "xriopteam" },
+    "links": {
+      "html": { "href": "https://bitbucket.org/xriopteam/demo-by-rik" },
+      "clone": [
+        { "name": "https", "href": "https://github.com/ritikrikm/my-app.git" }
+      ]
+    }
+  },
+  "pullrequest": {
+    "title": "feat: test webhook (created)",
+    "description": "Testing webhook for PR creation event.",
+    "author": { "display_name": "Ritik Mehta" },
+    "source": { "branch": { "name": "feature/add-rest-client" } },
+    "destination": { "branch": { "name": "main" } },
+    "links": {
+      "html": { "href": "https://bitbucket.org/xriopteam/demo-by-rik/pull-requests/1" }
+    }
+  }
+}

--- a/src/examples/bitbucket-pr-updated.http
+++ b/src/examples/bitbucket-pr-updated.http
@@ -1,0 +1,30 @@
+### Test Bitbucket Pull Request Updated Webhook
+# Simulates a PR update event (e.g. new commits pushed or description changed)
+
+POST http://localhost:3000/webhook/bitbucket/pr
+Content-Type: application/json
+x-event-key: pullrequest:updated
+x-hub-signature: sha256=dummy-signature
+
+{
+  "repository": {
+    "name": "demo-by-rik",
+    "workspace": { "slug": "xriopteam" },
+    "links": {
+      "html": { "href": "https://bitbucket.org/xriopteam/demo-by-rik" },
+      "clone": [
+        { "name": "https", "href": "https://github.com/ritikrikm/my-app.git" }
+      ]
+    }
+  },
+  "pullrequest": {
+    "title": "fix: update webhook payload (updated)",
+    "description": "Simulating PR update event.",
+    "author": { "display_name": "Ritik Mehta" },
+    "source": { "branch": { "name": "feature/add-rest-client" } },
+    "destination": { "branch": { "name": "main" } },
+    "links": {
+      "html": { "href": "https://bitbucket.org/xriopteam/demo-by-rik/pull-requests/1" }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds two .http example files under the examples/ directory to simplify local testing
of the Bitbucket webhook endpoint.

bitbucket-pr-created.http
bitbucket-pr-updated.http

These files can be used with the VS Code REST Client extension (Huachao Mao) to simulate
`pullrequest:created` and `pullrequest:updated` events locally.

No changes were made to existing code files.
